### PR TITLE
Confirm Contact Form

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "pedialab": {
     "caseStudySource": "case-study-source",
-    "contactFormEndpoint": "https://peraperatom.app.n8n.cloud/webhook/31fcabf0-492e-4996-86f0-f7ac041381de"
+    "contactFormEndpoint": "https://tomtsangperapera.app.n8n.cloud/webhook/c32cc78e-5a8a-4287-983b-fbbc9ea4dc06"
   },
   "devDependencies": {
     "@babel/core": "^7.14.0",


### PR DESCRIPTION
## Issue: Contact form submit 

## Action 1. airtable webhook
- airtable webhook without `Access-Control-Allow-Origin`, and it's strict with the request Content-Type header of "application/json".  Therefore, the fetch post with no-cors mode will not work, which do not allow the header. 
- [ref 1: airtable webhook](https://support.airtable.com/hc/en-us/articles/1500003044161-Incoming-webhooks-trigger#h_01EZFJ2QVDJQA6SWQB2M4671PM)
- [ref 2: fetch no-cors mode](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#supplying_request_options)

## Action 2. n8n webhook

## Result
- Current we use `n8n` endpoint, it will not be blocked by mode no-cors. 
- ~~Need to be confirmed the n8n receive the correct data and parsed it correctly.~~
- n8n workflow, webhook (get simple request, body type is `text/plain`) -> To Flow Data ( parse raw text to JSON ) -> Slack notification ( with JSON content )
![image](https://user-images.githubusercontent.com/5541565/119140110-5d59b700-ba76-11eb-82e7-7802e72e8873.png)
```
{
  "name": "Pedia Lab n8n",
  "nodes": [
    {
      "parameters": {},
      "name": "Start",
      "type": "n8n-nodes-base.start",
      "typeVersion": 1,
      "position": [
        250,
        300
      ]
    },
    {
      "parameters": {
        "httpMethod": "POST",
        "path": "c32cc78e-5a8a-4287-983b-fbbc9ea4dc06",
        "responseMode": "lastNode",
        "responseData": "allEntries",
        "options": {
          "responseHeaders": {
            "entries": []
          }
        }
      },
      "name": "Webhook",
      "type": "n8n-nodes-base.webhook",
      "typeVersion": 1,
      "position": [
        570,
        290
      ],
      "webhookId": "c32cc78e-5a8a-4287-983b-fbbc9ea4dc06"
    },
    {
      "parameters": {
        "authentication": "oAuth2",
        "channel": "#bd",
        "text": "=Client-Name: {{$node[\"To Flow Data\"].json[\"name\"]}}\nClient-Email: {{$node[\"To Flow Data\"].json[\"email\"]}}\nClient-Phone: {{$node[\"To Flow Data\"].json[\"phone\"]}}\nClient-Company: {{$node[\"To Flow Data\"].json[\"company\"]}}\nClient-Message:\n{{$node[\"To Flow Data\"].json[\"message\"]}}",
        "jsonParameters": "=false",
        "attachments": [],
        "otherOptions": {}
      },
      "name": "Slack",
      "type": "n8n-nodes-base.slack",
      "typeVersion": 1,
      "position": [
        1170,
        290
      ],
      "credentials": {
        "slackOAuth2Api": "Slack API "
      }
    },
    {
      "parameters": {
        "functionCode": "item = JSON.parse($node[\"Webhook\"].json[\"body\"]);\nreturn item;"
      },
      "name": "To Flow Data",
      "type": "n8n-nodes-base.functionItem",
      "position": [
        860,
        290
      ],
      "typeVersion": 1
    }
  ],
  "connections": {
    "Webhook": {
      "main": [
        [
          {
            "node": "To Flow Data",
            "type": "main",
            "index": 0
          }
        ]
      ]
    },
    "To Flow Data": {
      "main": [
        [
          {
            "node": "Slack",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "active": true,
  "settings": {},
  "id": "1001"
}
```

## Solutions
- It cannot be solved without server-side support. Options below
    1. Endpoint server should set CORS header, `Access-Control-Allow-Origin`, Not work in `Airtable`, `n8n`
    2. We should set up CORS proxy server by ourselves. We can try on Strapi server 
